### PR TITLE
Reuse precomputed float buckets in AtFloatHistogram

### DIFF
--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -882,19 +882,11 @@ func (it *histogramIterator) AtFloatHistogram(fh *histogram.FloatHistogram) (int
 	fh.NegativeSpans = resize(fh.NegativeSpans, len(it.nSpans))
 	copy(fh.NegativeSpans, it.nSpans)
 
-	fh.PositiveBuckets = resize(fh.PositiveBuckets, len(it.pBuckets))
-	var currentPositive float64
-	for i, b := range it.pBuckets {
-		currentPositive += float64(b)
-		fh.PositiveBuckets[i] = currentPositive
-	}
+	fh.PositiveBuckets = resize(fh.PositiveBuckets, len(it.pFloatBuckets))
+	copy(fh.PositiveBuckets, it.pFloatBuckets)
 
-	fh.NegativeBuckets = resize(fh.NegativeBuckets, len(it.nBuckets))
-	var currentNegative float64
-	for i, b := range it.nBuckets {
-		currentNegative += float64(b)
-		fh.NegativeBuckets[i] = currentNegative
-	}
+	fh.NegativeBuckets = resize(fh.NegativeBuckets, len(it.nFloatBuckets))
+	copy(fh.NegativeBuckets, it.nFloatBuckets)
 
 	fh.CustomValues = resize(fh.CustomValues, len(it.customValues))
 	copy(fh.CustomValues, it.customValues)

--- a/tsdb/chunkenc/histogram_test.go
+++ b/tsdb/chunkenc/histogram_test.go
@@ -1023,6 +1023,112 @@ func TestAtFloatHistogram(t *testing.T) {
 		require.Equal(t, expOutput[i], h, "histogram %d unequal", i)
 		i++
 	}
+	require.NoError(t, it.Err())
+	require.Len(t, expOutput, int(i))
+
+	// Now do the same, but recycle the same FloatHistogram across all
+	// samples, which exercises the copying branch of AtFloatHistogram. The
+	// pre-populated slices are longer than needed to make sure they get
+	// resized and fully overwritten.
+	it = chk.Iterator(it)
+	i = int64(0)
+	fh := &histogram.FloatHistogram{
+		PositiveSpans:   make([]histogram.Span, 5),
+		NegativeSpans:   make([]histogram.Span, 5),
+		PositiveBuckets: []float64{7, 7, 7, 7, 7, 7, 7, 7, 7, 7},
+		NegativeBuckets: []float64{7, 7, 7, 7, 7, 7, 7, 7, 7, 7},
+	}
+	for it.Next() != ValNone {
+		ts, h := it.AtFloatHistogram(fh)
+		require.Same(t, fh, h)
+		require.Equal(t, i, ts)
+		require.Equal(t, expOutput[i], h, "histogram %d unequal", i)
+		i++
+	}
+	require.NoError(t, it.Err())
+	require.Len(t, expOutput, int(i))
+
+	// Interleave AtHistogram(nil) and AtFloatHistogram(nil), which make the
+	// iterator hand out and then recycle its bucket slices, with
+	// AtFloatHistogram into a reused FloatHistogram.
+	it = chk.Iterator(it)
+	i = int64(0)
+	fh = &histogram.FloatHistogram{}
+	for it.Next() != ValNone {
+		_, h := it.AtHistogram(nil)
+		_, sharedFh := it.AtFloatHistogram(nil)
+		require.Equal(t, expOutput[i], sharedFh, "shared float histogram %d unequal", i)
+		ts, gotFh := it.AtFloatHistogram(fh)
+		require.Same(t, fh, gotFh)
+		require.Equal(t, i, ts)
+		require.Equal(t, expOutput[i], gotFh, "float histogram %d unequal", i)
+		require.Equal(t, expOutput[i], h.ToFloat(nil), "histogram %d unequal", i)
+		i++
+	}
+	require.NoError(t, it.Err())
+	require.Len(t, expOutput, int(i))
+}
+
+func TestAtFloatHistogramCustomBucketsReuse(t *testing.T) {
+	input := []histogram.Histogram{
+		{
+			Schema:          histogram.CustomBucketsSchema,
+			Count:           7,
+			Sum:             1234.5,
+			PositiveSpans:   []histogram.Span{{Offset: 0, Length: 3}},
+			PositiveBuckets: []int64{1, 1, 2},
+			CustomValues:    []float64{1, 2, 5},
+		},
+		{
+			Schema:          histogram.CustomBucketsSchema,
+			Count:           12,
+			Sum:             2345.6,
+			PositiveSpans:   []histogram.Span{{Offset: 0, Length: 3}},
+			PositiveBuckets: []int64{3, 1, 1},
+			CustomValues:    []float64{1, 2, 5},
+		},
+	}
+	expOutput := []*histogram.FloatHistogram{
+		{
+			Schema:          histogram.CustomBucketsSchema,
+			Count:           7,
+			Sum:             1234.5,
+			PositiveSpans:   []histogram.Span{{Offset: 0, Length: 3}},
+			PositiveBuckets: []float64{1, 2, 4},
+			CustomValues:    []float64{1, 2, 5},
+		},
+		{
+			CounterResetHint: histogram.NotCounterReset,
+			Schema:           histogram.CustomBucketsSchema,
+			Count:            12,
+			Sum:              2345.6,
+			PositiveSpans:    []histogram.Span{{Offset: 0, Length: 3}},
+			PositiveBuckets:  []float64{3, 4, 5},
+			CustomValues:     []float64{1, 2, 5},
+		},
+	}
+
+	chk := NewHistogramChunk()
+	app, err := chk.Appender()
+	require.NoError(t, err)
+	for i := range input {
+		newc, _, _, err := app.AppendHistogram(nil, int64(i), &input[i], false)
+		require.NoError(t, err)
+		require.Nil(t, newc)
+	}
+
+	it := chk.Iterator(nil)
+	i := int64(0)
+	fh := &histogram.FloatHistogram{}
+	for it.Next() != ValNone {
+		ts, h := it.AtFloatHistogram(fh)
+		require.Same(t, fh, h)
+		require.Equal(t, i, ts)
+		require.Equal(t, expOutput[i], h, "histogram %d unequal", i)
+		i++
+	}
+	require.NoError(t, it.Err())
+	require.Len(t, expOutput, int(i))
 }
 
 func TestHistogramChunkAppendableGauge(t *testing.T) {


### PR DESCRIPTION
## Summary

`histogramIterator` already maintains absolute float bucket counts (`pFloatBuckets` / `nFloatBuckets`) on every `Next()`, and the non-copying branch of `AtFloatHistogram` (when the caller passes `nil`) returns those slices directly. The copying branch instead recomputed the cumulative sums by accumulating `float64(delta)` over `pBuckets` / `nBuckets`.

This replaces that recomputation with a `copy` of the already-maintained float buckets, so:
- both branches of `AtFloatHistogram` produce identical values (the float accumulation can drift from the `int64` cumulative sum for counts beyond 2^53),
- the per-sample loop becomes a `memmove`.

## Safety

`pFloatBuckets` / `nFloatBuckets` are written unconditionally for every bucket in both the first-sample and the delta-of-delta paths of `Next()`, and are allocated alongside `pBuckets` / `nBuckets`, so their length always matches. Callers that got a shared slice handed out (`AtHistogram(nil)` / `AtFloatHistogram(nil)`) cause the iterator to re-allocate the slices, and they are fully overwritten before the next sample is readable.

## Tests

`TestAtFloatHistogram` previously only exercised `AtFloatHistogram(nil)` — the copying branch had no coverage in `chunkenc`. Added:
- a pass that recycles one `*FloatHistogram` across all samples, pre-populated with oversized bucket slices to exercise `resize`,
- a pass interleaving `AtHistogram(nil)` and `AtFloatHistogram(nil)` with the reused `*FloatHistogram`, covering the slice-recycling interplay,
- `TestAtFloatHistogramCustomBucketsReuse` for custom-bucket schemas.

Verified the new assertions fail if the `pFloatBuckets` update is dropped from `Next()`. `go test ./tsdb/... ./promql/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)